### PR TITLE
adding write_traces_sync for those poor serverless fools

### DIFF
--- a/src/reprompt/__init__.py
+++ b/src/reprompt/__init__.py
@@ -5,15 +5,15 @@ from __future__ import annotations
 import logging
 
 from . import config
-from .tracing import FunctionTrace, get_edits, write_traces
+from .tracing import FunctionTrace, get_edits, write_traces, write_traces_sync
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 # IMPORTANT: setting version for Reprompt package
-__version__ = "0.0.7.6"
+__version__ = "0.0.7.7"
 # IMPORTANT: All the functions we want to expose publicly from the reprompt module
-__all__ = ["init", "FunctionTrace", "write_traces", "get_edits"]
+__all__ = ["init", "FunctionTrace", "write_traces", "get_edits", "write_traces_sync"]
 
 
 def init(api_base_url: str = None, api_key: str = None, debug: bool = False):


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->




| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 7358bbda3c639c8f8110c96cdf326aeb9f142bd1  | 
|--------|

### Summary:
This PR adds a synchronous version of `write_traces`, `write_traces_sync`, to the `reprompt` module for serverless applications, and modifies `upload_traces` to use `requests` instead of `aiohttp`.

**Key points**:
- Added `write_traces_sync` to `src/reprompt/tracing.py` and `src/reprompt/__init__.py`
- Modified `upload_traces` in `src/reprompt/tracing.py` to use `requests` instead of `aiohttp`
- Updated `write_traces` in `src/reprompt/tracing.py` to run `upload_traces` in a separate thread
- Incremented version number in `src/reprompt/__init__.py`


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
